### PR TITLE
Exceptions

### DIFF
--- a/exceptions.go
+++ b/exceptions.go
@@ -1,7 +1,10 @@
 package grohl
 
 import (
+	"bytes"
 	"reflect"
+	"runtime/debug"
+	"strconv"
 )
 
 type ExceptionReporter interface {
@@ -15,6 +18,10 @@ type ExceptionLogReporter struct {
 
 func (r *ExceptionLogReporter) Report(err error, data map[string]interface{}) {
 	r.logger.Log(data)
+	for _, line := range ErrorBacktraceLines(err) {
+		data["site"] = line
+		r.logger.Log(data)
+	}
 }
 
 type ExceptionLogger struct {
@@ -40,9 +47,36 @@ func (l *ExceptionLogger) Report(err error, data map[string]interface{}) {
 	l.Reporter.Report(err, merged)
 }
 
+func ErrorBacktrace(err error) string {
+	lines := errorBacktraceBytes(err)
+	return string(bytes.Join(lines, byteLineBreak))
+}
+
+func ErrorBacktraceLines(err error) []string {
+	byteLines := errorBacktraceBytes(err)
+	lines := make([]string, len(byteLines))
+	for i, byteline := range byteLines {
+		lines[i] = string(byteline)
+	}
+	return lines
+}
+
+func errorBacktraceBytes(err error) [][]byte {
+	backtrace := debug.Stack()
+	all := bytes.Split(backtrace, byteLineBreak)
+	return all[4 : len(all)-1]
+}
+
+func ErrorId(err error) string {
+	id := int(reflect.ValueOf(err).Pointer())
+	return strconv.Itoa(id)
+}
+
 func errorToMap(err error, data map[string]interface{}) {
 	data["at"] = "exception"
 	data["class"] = reflect.TypeOf(err).String()
 	data["message"] = err.Error()
-	data["exception_id"] = int64(reflect.ValueOf(err).Pointer())
+	data["exception_id"] = ErrorId(err)
 }
+
+var byteLineBreak = []byte{'\n'}

--- a/exceptions.go
+++ b/exceptions.go
@@ -29,11 +29,7 @@ type ExceptionLogger struct {
 	*IoLogger
 }
 
-func NewExceptionLogger(logger *IoLogger, reporter ExceptionReporter) *ExceptionLogger {
-	if logger == nil {
-		logger = defaultLogger
-	}
-
+func newExceptionLogger(logger *IoLogger, reporter ExceptionReporter) *ExceptionLogger {
 	if reporter == nil {
 		reporter = &ExceptionLogReporter{logger}
 	}

--- a/exceptions.go
+++ b/exceptions.go
@@ -1,0 +1,47 @@
+package grohl
+
+import (
+	"reflect"
+)
+
+type ExceptionReporter interface {
+	Report(err error, data map[string]interface{})
+}
+
+// Implementation of ExceptionReporter that writes to a grohl logger.
+type ExceptionLogReporter struct {
+	logger Logger
+}
+
+func (r *ExceptionLogReporter) Report(err error, data map[string]interface{}) {
+	r.logger.Log(data)
+}
+
+type ExceptionLogger struct {
+	Reporter ExceptionReporter
+	*IoLogger
+}
+
+func NewExceptionLogger(logger *IoLogger, reporter ExceptionReporter) *ExceptionLogger {
+	if logger == nil {
+		logger = defaultLogger
+	}
+
+	if reporter == nil {
+		reporter = &ExceptionLogReporter{logger}
+	}
+
+	return &ExceptionLogger{reporter, logger}
+}
+
+func (l *ExceptionLogger) Report(err error, data map[string]interface{}) {
+	merged := dupeMaps(l.context, data)
+	errorToMap(err, merged)
+	l.Reporter.Report(err, merged)
+}
+
+func errorToMap(err error, data map[string]interface{}) {
+	data["at"] = "exception"
+	data["class"] = reflect.TypeOf(err).String()
+	data["message"] = err.Error()
+}

--- a/exceptions.go
+++ b/exceptions.go
@@ -44,4 +44,5 @@ func errorToMap(err error, data map[string]interface{}) {
 	data["at"] = "exception"
 	data["class"] = reflect.TypeOf(err).String()
 	data["message"] = err.Error()
+	data["exception_id"] = int64(reflect.ValueOf(err).Pointer())
 }

--- a/exceptions_test.go
+++ b/exceptions_test.go
@@ -3,6 +3,7 @@ package grohl
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -12,10 +13,12 @@ func TestLogsException(t *testing.T) {
 	logger.AddContext("b", 1)
 
 	err := fmt.Errorf("Test")
+	errid := int64(reflect.ValueOf(err).Pointer())
 
 	logger.Report(err, LogData{"b": 2, "c": 3, "at": "overwrite me"})
-	if line := logged(buf); line != "a=1 b=2 c=3 at=exception class=*errors.errorString message=Test" {
-		t.Errorf("Line does not match: %s", line)
+	expected := fmt.Sprintf("a=1 b=2 c=3 at=exception class=*errors.errorString message=Test exception_id=%d", errid)
+	if line := logged(buf); line != expected {
+		t.Errorf("Line does not match:\ne: %s\na: %s", expected, line)
 	}
 }
 

--- a/exceptions_test.go
+++ b/exceptions_test.go
@@ -1,0 +1,25 @@
+package grohl
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestLogsException(t *testing.T) {
+	logger, buf := exceptionLoggerWithBuffer()
+	logger.AddContext("a", 1)
+	logger.AddContext("b", 1)
+
+	err := fmt.Errorf("Test")
+
+	logger.Report(err, LogData{"b": 2, "c": 3, "at": "overwrite me"})
+	if line := logged(buf); line != "a=1 b=2 c=3 at=exception class=*errors.errorString message=Test" {
+		t.Errorf("Line does not match: %s", line)
+	}
+}
+
+func exceptionLoggerWithBuffer() (*ExceptionLogger, *bytes.Buffer) {
+	logger, buf := loggerWithBuffer()
+	return logger.NewExceptionLogger(nil), buf
+}

--- a/grohl.go
+++ b/grohl.go
@@ -10,6 +10,10 @@ func NewContext(data map[string]interface{}) *IoLogger {
 	return defaultLogger.NewContext(data)
 }
 
+func NewExceptionLogger(reporter ExceptionReporter) *ExceptionLogger {
+	return newExceptionLogger(defaultLogger, reporter)
+}
+
 func AddContext(key string, value interface{}) {
 	defaultLogger.AddContext(key, value)
 }

--- a/grohl.go
+++ b/grohl.go
@@ -1,35 +1,35 @@
 package grohl
 
-var logger = NewLogger(nil)
+var defaultLogger = NewLogger(nil)
 
 func Log(data map[string]interface{}) {
-	logger.Log(data)
+	defaultLogger.Log(data)
 }
 
 func NewContext(data map[string]interface{}) *IoLogger {
-	return logger.NewContext(data)
+	return defaultLogger.NewContext(data)
 }
 
 func AddContext(key string, value interface{}) {
-	logger.AddContext(key, value)
+	defaultLogger.AddContext(key, value)
 }
 
 func DeleteContext(key string) {
-	logger.DeleteContext(key)
+	defaultLogger.DeleteContext(key)
 }
 
 func NewTimer(context map[string]interface{}) *Timer {
-	return logger.NewTimer(context)
+	return defaultLogger.NewTimer(context)
 }
 
 func SetLogger(l *IoLogger) {
-	logger = l
+	defaultLogger = l
 }
 
 func SetTimeUnit(unit string) {
-	logger.TimeUnit = unit
+	defaultLogger.TimeUnit = unit
 }
 
 func TimeUnit() string {
-	return logger.TimeUnit
+	return defaultLogger.TimeUnit
 }

--- a/logger.go
+++ b/logger.go
@@ -50,6 +50,10 @@ func (l *IoLogger) NewContext(data map[string]interface{}) *IoLogger {
 	return ctx
 }
 
+func (l *IoLogger) NewExceptionLogger(reporter ExceptionReporter) *ExceptionLogger {
+	return NewExceptionLogger(l, reporter)
+}
+
 func (l *IoLogger) AddContext(key string, value interface{}) {
 	l.context[key] = value
 }

--- a/logger.go
+++ b/logger.go
@@ -51,7 +51,7 @@ func (l *IoLogger) NewContext(data map[string]interface{}) *IoLogger {
 }
 
 func (l *IoLogger) NewExceptionLogger(reporter ExceptionReporter) *ExceptionLogger {
-	return NewExceptionLogger(l, reporter)
+	return newExceptionLogger(l, reporter)
 }
 
 func (l *IoLogger) AddContext(key string, value interface{}) {

--- a/statter.go
+++ b/statter.go
@@ -11,7 +11,7 @@ type Statter struct {
 
 func NewStatter(l Logger) *Statter {
 	if l == nil {
-		l = logger
+		l = defaultLogger
 	}
 	return &Statter{l}
 }


### PR DESCRIPTION
Implemented exception logging as part of grohl.  [Heavily inspired by scrolls](https://github.com/asenchi/scrolls/blob/5f97cb90aeb3aae68b1f5fd061b9b03c49e17717/lib/scrolls/log.rb#L95-L118), as usual.  

First, create an exception logger.  If you don't specify a reporter, it will use the default reporter that logs through grohl.

``` go
err := fmt.Errorf("Sample Error")

reporter := grohl.NewExceptionLogger(nil)
reporter.Report(err, grohl.LogData{"app": "sample"})
```

/cc @asenchi
