### PR TITLE
the Timer object will write to a statter

### DIFF
--- a/context.go
+++ b/context.go
@@ -40,7 +40,7 @@ func (c *Context) Delete(key string) {
 
 func (c *Context) SetStatter(statter Statter, sampleRate float32, bucket string) {
 	if statter == nil {
-		c.statter = c
+		c.statter = CurrentStatter
 	} else {
 		c.statter = statter
 	}

--- a/context.go
+++ b/context.go
@@ -5,6 +5,9 @@ type Context struct {
 	Logger            Logger
 	TimeUnit          string
 	ExceptionReporter ExceptionReporter
+	statter           Statter
+	statSampleRate    float32
+	statBucket        string
 }
 
 func (c *Context) Log(data Data) error {
@@ -33,6 +36,16 @@ func (c *Context) Merge(data Data) Data {
 
 func (c *Context) Delete(key string) {
 	delete(c.data, key)
+}
+
+func (c *Context) SetStatter(statter Statter, sampleRate float32, bucket string) {
+	if statter == nil {
+		c.statter = c
+	} else {
+		c.statter = statter
+	}
+	c.statSampleRate = sampleRate
+	c.statBucket = bucket
 }
 
 func dupeMaps(maps ...Data) Data {

--- a/context.go
+++ b/context.go
@@ -5,9 +5,7 @@ type Context struct {
 	Logger            Logger
 	TimeUnit          string
 	ExceptionReporter ExceptionReporter
-	statter           Statter
-	statSampleRate    float32
-	statBucket        string
+	*_statter
 }
 
 func (c *Context) Log(data Data) error {
@@ -38,16 +36,6 @@ func (c *Context) Delete(key string) {
 	delete(c.data, key)
 }
 
-func (c *Context) SetStatter(statter Statter, sampleRate float32, bucket string) {
-	if statter == nil {
-		c.statter = CurrentStatter
-	} else {
-		c.statter = statter
-	}
-	c.statSampleRate = sampleRate
-	c.statBucket = bucket
-}
-
 func dupeMaps(maps ...Data) Data {
 	merged := make(Data)
 	for _, orig := range maps {
@@ -63,5 +51,7 @@ func newContext(data Data, logger Logger, timeunit string, reporter ExceptionRep
 		data:              data,
 		Logger:            logger,
 		TimeUnit:          timeunit,
-		ExceptionReporter: reporter}
+		ExceptionReporter: reporter,
+		_statter:          &_statter{},
+	}
 }

--- a/context.go
+++ b/context.go
@@ -16,7 +16,7 @@ func (c *Context) log(data Data) error {
 }
 
 func (c *Context) New(data Data) *Context {
-	return &Context{c.Merge(data), c.Logger, c.TimeUnit, c.ExceptionReporter}
+	return newContext(c.Merge(data), c.Logger, c.TimeUnit, c.ExceptionReporter)
 }
 
 func (c *Context) Add(key string, value interface{}) {
@@ -43,4 +43,12 @@ func dupeMaps(maps ...Data) Data {
 		}
 	}
 	return merged
+}
+
+func newContext(data Data, logger Logger, timeunit string, reporter ExceptionReporter) *Context {
+	return &Context{
+		data:              data,
+		Logger:            logger,
+		TimeUnit:          timeunit,
+		ExceptionReporter: reporter}
 }

--- a/exceptions_test.go
+++ b/exceptions_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLogsException(t *testing.T) {
-	reporter, buf := setupLogger()
+	reporter, buf := setupLogger(t)
 	reporter.Add("a", 1)
 	reporter.Add("b", 1)
 
@@ -17,7 +17,7 @@ func TestLogsException(t *testing.T) {
 	expected := "a=1 b=2 c=3 at=exception class=*errors.errorString message=Test"
 	linePrefix := expected + " site="
 
-	for i, line := range strings.Split(logged(buf), "\n") {
+	for i, line := range strings.Split(buf.String(), "\n") {
 		if i == 0 {
 			if line != expected {
 				t.Errorf("Line does not match:\ne: %s\na: %s", expected, line)

--- a/grohl.go
+++ b/grohl.go
@@ -9,7 +9,7 @@ type Logger interface {
 }
 
 var CurrentLogger Logger = NewIoLogger(nil)
-var CurrentContext = &Context{make(Data), CurrentLogger, "s", nil}
+var CurrentContext = newContext(make(Data), CurrentLogger, "s", nil)
 var CurrentStatter Statter = CurrentContext
 
 func Log(data Data) {

--- a/grohl.go
+++ b/grohl.go
@@ -55,6 +55,10 @@ func DeleteContext(key string) {
 	CurrentContext.Delete(key)
 }
 
+func SetStatter(statter Statter, sampleRate float32, bucket string) {
+	CurrentContext.SetStatter(statter, sampleRate, bucket)
+}
+
 func NewTimer(data Data) *Timer {
 	return CurrentContext.Timer(data)
 }

--- a/statter.go
+++ b/statter.go
@@ -1,7 +1,9 @@
 package grohl
 
 import (
+	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 )
 
@@ -42,9 +44,9 @@ func (c *Context) Gauge(sampleRate float32, bucket string, value ...string) {
 }
 
 type _statter struct {
-	statter        Statter
-	statSampleRate float32
-	statBucket     string
+	statter           Statter
+	StatterSampleRate float32
+	StatterBucket     string
 }
 
 func (s *_statter) SetStatter(statter Statter, sampleRate float32, bucket string) {
@@ -53,8 +55,16 @@ func (s *_statter) SetStatter(statter Statter, sampleRate float32, bucket string
 	} else {
 		s.statter = statter
 	}
-	s.statSampleRate = sampleRate
-	s.statBucket = bucket
+	s.StatterSampleRate = sampleRate
+	s.StatterBucket = bucket
+}
+
+func (s *_statter) StatterBucketSuffix(suffix string) {
+	sep := "."
+	if strings.HasSuffix(s.StatterBucket, ".") {
+		sep = ""
+	}
+	s.StatterBucket = s.StatterBucket + fmt.Sprintf("%s%s", sep, suffix)
 }
 
 func (s *_statter) Timing(dur time.Duration) {
@@ -62,9 +72,9 @@ func (s *_statter) Timing(dur time.Duration) {
 		return
 	}
 
-	s.statter.Timing(s.statSampleRate, s.statBucket, dur)
+	s.statter.Timing(s.StatterSampleRate, s.StatterBucket, dur)
 }
 
 func (s *_statter) dup() *_statter {
-	return &_statter{s.statter, s.statSampleRate, s.statBucket}
+	return &_statter{s.statter, s.StatterSampleRate, s.StatterBucket}
 }

--- a/statter.go
+++ b/statter.go
@@ -64,3 +64,7 @@ func (s *_statter) Timing(dur time.Duration) {
 
 	s.statter.Timing(s.statSampleRate, s.statBucket, dur)
 }
+
+func (s *_statter) dup() *_statter {
+	return &_statter{s.statter, s.statSampleRate, s.statBucket}
+}

--- a/statter.go
+++ b/statter.go
@@ -40,3 +40,27 @@ func (c *Context) Gauge(sampleRate float32, bucket string, value ...string) {
 		c.Log(Data{"metric": bucket, "gauge": v})
 	}
 }
+
+type _statter struct {
+	statter        Statter
+	statSampleRate float32
+	statBucket     string
+}
+
+func (s *_statter) SetStatter(statter Statter, sampleRate float32, bucket string) {
+	if statter == nil {
+		s.statter = CurrentStatter
+	} else {
+		s.statter = statter
+	}
+	s.statSampleRate = sampleRate
+	s.statBucket = bucket
+}
+
+func (s *_statter) Timing(dur time.Duration) {
+	if s.statter == nil {
+		return
+	}
+
+	s.statter.Timing(s.statSampleRate, s.statBucket, dur)
+}

--- a/statter_test.go
+++ b/statter_test.go
@@ -25,3 +25,16 @@ func TestLogsGauge(t *testing.T) {
 	s.Gauge(1.0, "a", "1", "2")
 	buf.AssertLogged("metric=a gauge=1\nmetric=a gauge=2")
 }
+
+var suffixTests = []string{"abc", "abc."}
+
+func TestSetsBucketSuffix(t *testing.T) {
+	s, _ := setupLogger(t)
+	for _, prefix := range suffixTests {
+		s.StatterBucket = prefix
+		s.StatterBucketSuffix("def")
+		if s.StatterBucket != "abc.def" {
+			t.Errorf("bucket is wrong after prefix %s: %s", prefix, s.StatterBucket)
+		}
+	}
+}

--- a/statter_test.go
+++ b/statter_test.go
@@ -6,28 +6,22 @@ import (
 )
 
 func TestLogsCounter(t *testing.T) {
-	s, buf := setupLogger()
+	s, buf := setupLogger(t)
 	s.Counter(1.0, "a", 1, 2)
-	if line := logged(buf); line != "metric=a count=1\nmetric=a count=2" {
-		t.Errorf("Bad log output: %q", line)
-	}
+	buf.AssertLogged("metric=a count=1\nmetric=a count=2")
 }
 
 func TestLogsTiming(t *testing.T) {
-	s, buf := setupLogger()
+	s, buf := setupLogger(t)
 	dur1, _ := time.ParseDuration("15ms")
 	dur2, _ := time.ParseDuration("3s")
 
 	s.Timing(1.0, "a", dur1, dur2)
-	if line := logged(buf); line != "metric=a timing=15\nmetric=a timing=3000" {
-		t.Errorf("Bad log output: %q", line)
-	}
+	buf.AssertLogged("metric=a timing=15\nmetric=a timing=3000")
 }
 
 func TestLogsGauge(t *testing.T) {
-	s, buf := setupLogger()
+	s, buf := setupLogger(t)
 	s.Gauge(1.0, "a", "1", "2")
-	if line := logged(buf); line != "metric=a gauge=1\nmetric=a gauge=2" {
-		t.Errorf("Bad log output: %q", line)
-	}
+	buf.AssertLogged("metric=a gauge=1\nmetric=a gauge=2")
 }

--- a/timer.go
+++ b/timer.go
@@ -19,7 +19,7 @@ func (c *Context) Timer(data Data) *Timer {
 
 // Writes a final log message with the elapsed time shown.
 func (t *Timer) Finish() {
-	t.Log(nil)
+	t.Log(Data{"at": "finish"})
 }
 
 // Writes a log message with extra data or the elapsed time shown.  Pass nil or
@@ -29,7 +29,6 @@ func (t *Timer) Log(data Data) error {
 		data = make(Data)
 	}
 
-	data["at"] = "finish"
 	data["elapsed"] = t.durationUnit(t.Elapsed())
 	return t.context.Log(data)
 }

--- a/timer.go
+++ b/timer.go
@@ -19,7 +19,7 @@ func (c *Context) Timer(data Data) *Timer {
 		Started:  time.Now(),
 		TimeUnit: context.TimeUnit,
 		context:  context,
-		_statter: c._statter,
+		_statter: c._statter.dup(),
 	}
 }
 

--- a/timer.go
+++ b/timer.go
@@ -55,7 +55,7 @@ func (t *Timer) Elapsed() time.Duration {
 
 func (t *Timer) SetStatter(statter Statter, sampleRate float32, bucket string) {
 	if statter == nil {
-		t.statter = t.context
+		t.statter = CurrentStatter
 	} else {
 		t.statter = statter
 	}

--- a/timer.go
+++ b/timer.go
@@ -17,7 +17,11 @@ type Timer struct {
 func (c *Context) Timer(data Data) *Timer {
 	context := c.New(data)
 	context.Log(Data{"at": "start"})
-	return &Timer{Started: time.Now(), TimeUnit: context.TimeUnit, context: context}
+	timer := &Timer{Started: time.Now(), TimeUnit: context.TimeUnit, context: context}
+	if c.statter != nil {
+		timer.SetStatter(c.statter, c.statSampleRate, c.statBucket)
+	}
+	return timer
 }
 
 // Writes a final log message with the elapsed time shown.

--- a/timer_test.go
+++ b/timer_test.go
@@ -5,18 +5,16 @@ import (
 )
 
 func TestTimerLog(t *testing.T) {
-	context, buf := setupLogger()
+	context, buf := setupLogger(t)
 	context.Add("a", "1")
 	timer := context.Timer(Data{"b": "2"})
 	timer.Log(Data{"c": "3"})
 
-	if result := logged(buf); result != "a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.000" {
-		t.Errorf("Bad log output: %s", result)
-	}
+	buf.AssertLogged("a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.000")
 }
 
 func TestTimerLogInMS(t *testing.T) {
-	context, buf := setupLogger()
+	context, buf := setupLogger(t)
 	context.Add("a", "1")
 	timer := context.Timer(Data{"b": "2"})
 	timer.TimeUnit = "ms"
@@ -24,24 +22,22 @@ func TestTimerLogInMS(t *testing.T) {
 
 	expected := "a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.001"
 	checkedLen := len(expected) - 3
-	if result := logged(buf); result[0:checkedLen] != expected[0:checkedLen] {
+	if result := buf.String(); result[0:checkedLen] != expected[0:checkedLen] {
 		t.Errorf("Bad log output: %s", result)
 	}
 }
 
 func TestTimerFinish(t *testing.T) {
-	context, buf := setupLogger()
+	context, buf := setupLogger(t)
 	context.Add("a", "1")
 	timer := context.Timer(Data{"b": "2"})
 	timer.Finish()
 
-	if result := logged(buf); result != "a=1 b=2 at=start\na=1 b=2 at=finish elapsed=0.000" {
-		t.Errorf("Bad log output: %s", result)
-	}
+	buf.AssertLogged("a=1 b=2 at=start\na=1 b=2 at=finish elapsed=0.000")
 }
 
 func TestTimerWithStatter(t *testing.T) {
-	context, buf := setupLogger()
+	context, buf := setupLogger(t)
 	context.Add("a", "1")
 	timer := context.Timer(Data{"b": "2"})
 	statter := NewContext(nil)
@@ -52,13 +48,11 @@ func TestTimerWithStatter(t *testing.T) {
 	expected := "a=1 b=2 at=start\n"
 	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
 	expected = expected + "metric=bucket timing=0"
-	if result := logged(buf); result != expected {
-		t.Errorf("Bad log output: %s", result)
-	}
+	buf.AssertLogged(expected)
 }
 
 func TestTimerWithContextStatter(t *testing.T) {
-	context, buf := setupLogger()
+	context, buf := setupLogger(t)
 	context.Add("a", "1")
 	context.SetStatter(context, 1.0, "bucket")
 	timer := context.Timer(Data{"b": "2"})
@@ -67,15 +61,13 @@ func TestTimerWithContextStatter(t *testing.T) {
 	expected := "a=1 b=2 at=start\n"
 	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
 	expected = expected + "a=1 metric=bucket timing=0"
-	if result := logged(buf); result != expected {
-		t.Errorf("Bad log output: %s", result)
-	}
+	buf.AssertLogged(expected)
 }
 
 func TestTimerWithNilStatter(t *testing.T) {
 	oldlogger := CurrentContext.Logger
 
-	context, buf := setupLogger()
+	context, buf := setupLogger(t)
 	context.Add("a", "1")
 	CurrentContext.Logger = context.Logger
 	timer := context.Timer(Data{"b": "2"})
@@ -87,7 +79,5 @@ func TestTimerWithNilStatter(t *testing.T) {
 	expected := "a=1 b=2 at=start\n"
 	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
 	expected = expected + "metric=bucket timing=0"
-	if result := logged(buf); result != expected {
-		t.Errorf("Bad log output: %s", result)
-	}
+	buf.AssertLogged(expected)
 }

--- a/timer_test.go
+++ b/timer_test.go
@@ -56,7 +56,7 @@ func TestTimerWithContextStatter(t *testing.T) {
 	context.Add("a", "1")
 	context.SetStatter(context, 1.0, "bucket")
 	timer := context.Timer(Data{"b": "2"})
-	timer.statBucket = "bucket2"
+	timer.StatterBucket = "bucket2"
 	timer.Finish()
 
 	expected := "a=1 b=2 at=start\n"
@@ -64,7 +64,7 @@ func TestTimerWithContextStatter(t *testing.T) {
 	expected = expected + "a=1 metric=bucket2 timing=0"
 	buf.AssertLogged(expected)
 
-	if context.statBucket == "bucket2" {
+	if context.StatterBucket == "bucket2" {
 		t.Errorf("Context's stat bucket was changed")
 	}
 }

--- a/timer_test.go
+++ b/timer_test.go
@@ -39,3 +39,35 @@ func TestTimerFinish(t *testing.T) {
 		t.Errorf("Bad log output: %s", result)
 	}
 }
+
+func TestTimerWithStatter(t *testing.T) {
+	context, buf := setupLogger()
+	context.Add("a", "1")
+	timer := context.Timer(Data{"b": "2"})
+	statter := NewContext(nil)
+	statter.Logger = context.Logger
+	timer.SetStatter(statter, 1.0, "bucket")
+	timer.Finish()
+
+	expected := "a=1 b=2 at=start\n"
+	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
+	expected = expected + "metric=bucket timing=0"
+	if result := logged(buf); result != expected {
+		t.Errorf("Bad log output: %s", result)
+	}
+}
+
+func TestTimerWithNilStatter(t *testing.T) {
+	context, buf := setupLogger()
+	context.Add("a", "1")
+	timer := context.Timer(Data{"b": "2"})
+	timer.SetStatter(nil, 1.0, "bucket")
+	timer.Finish()
+
+	expected := "a=1 b=2 at=start\n"
+	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
+	expected = expected + "a=1 b=2 metric=bucket timing=0"
+	if result := logged(buf); result != expected {
+		t.Errorf("Bad log output: %s", result)
+	}
+}

--- a/timer_test.go
+++ b/timer_test.go
@@ -4,27 +4,38 @@ import (
 	"testing"
 )
 
-func TestTimer(t *testing.T) {
+func TestTimerLog(t *testing.T) {
 	context, buf := setupLogger()
 	context.Add("a", "1")
 	timer := context.Timer(Data{"b": "2"})
-	timer.Log(Data{"at": "clobbered", "c": "3"})
+	timer.Log(Data{"c": "3"})
 
-	if result := logged(buf); result != "a=1 b=2 at=start\na=1 b=2 at=finish c=3 elapsed=0.000" {
+	if result := logged(buf); result != "a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.000" {
 		t.Errorf("Bad log output: %s", result)
 	}
 }
 
-func TestTimerInMS(t *testing.T) {
+func TestTimerLogInMS(t *testing.T) {
 	context, buf := setupLogger()
 	context.Add("a", "1")
 	timer := context.Timer(Data{"b": "2"})
 	timer.TimeUnit = "ms"
-	timer.Log(Data{"at": "clobbered", "c": "3"})
+	timer.Log(Data{"c": "3"})
 
-	expected := "a=1 b=2 at=start\na=1 b=2 at=finish c=3 elapsed=0.001"
+	expected := "a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.001"
 	checkedLen := len(expected) - 3
 	if result := logged(buf); result[0:checkedLen] != expected[0:checkedLen] {
+		t.Errorf("Bad log output: %s", result)
+	}
+}
+
+func TestTimerFinish(t *testing.T) {
+	context, buf := setupLogger()
+	context.Add("a", "1")
+	timer := context.Timer(Data{"b": "2"})
+	timer.Finish()
+
+	if result := logged(buf); result != "a=1 b=2 at=start\na=1 b=2 at=finish elapsed=0.000" {
 		t.Errorf("Bad log output: %s", result)
 	}
 }

--- a/timer_test.go
+++ b/timer_test.go
@@ -57,6 +57,21 @@ func TestTimerWithStatter(t *testing.T) {
 	}
 }
 
+func TestTimerWithContextStatter(t *testing.T) {
+	context, buf := setupLogger()
+	context.Add("a", "1")
+	context.SetStatter(nil, 1.0, "bucket")
+	timer := context.Timer(Data{"b": "2"})
+	timer.Finish()
+
+	expected := "a=1 b=2 at=start\n"
+	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
+	expected = expected + "a=1 metric=bucket timing=0"
+	if result := logged(buf); result != expected {
+		t.Errorf("Bad log output: %s", result)
+	}
+}
+
 func TestTimerWithNilStatter(t *testing.T) {
 	context, buf := setupLogger()
 	context.Add("a", "1")

--- a/timer_test.go
+++ b/timer_test.go
@@ -56,12 +56,17 @@ func TestTimerWithContextStatter(t *testing.T) {
 	context.Add("a", "1")
 	context.SetStatter(context, 1.0, "bucket")
 	timer := context.Timer(Data{"b": "2"})
+	timer.statBucket = "bucket2"
 	timer.Finish()
 
 	expected := "a=1 b=2 at=start\n"
 	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
-	expected = expected + "a=1 metric=bucket timing=0"
+	expected = expected + "a=1 metric=bucket2 timing=0"
 	buf.AssertLogged(expected)
+
+	if context.statBucket == "bucket2" {
+		t.Errorf("Context's stat bucket was changed")
+	}
 }
 
 func TestTimerWithNilStatter(t *testing.T) {

--- a/timer_test.go
+++ b/timer_test.go
@@ -60,7 +60,7 @@ func TestTimerWithStatter(t *testing.T) {
 func TestTimerWithContextStatter(t *testing.T) {
 	context, buf := setupLogger()
 	context.Add("a", "1")
-	context.SetStatter(nil, 1.0, "bucket")
+	context.SetStatter(context, 1.0, "bucket")
 	timer := context.Timer(Data{"b": "2"})
 	timer.Finish()
 
@@ -73,15 +73,20 @@ func TestTimerWithContextStatter(t *testing.T) {
 }
 
 func TestTimerWithNilStatter(t *testing.T) {
+	oldlogger := CurrentContext.Logger
+
 	context, buf := setupLogger()
 	context.Add("a", "1")
+	CurrentContext.Logger = context.Logger
 	timer := context.Timer(Data{"b": "2"})
 	timer.SetStatter(nil, 1.0, "bucket")
 	timer.Finish()
 
+	CurrentContext.Logger = oldlogger
+
 	expected := "a=1 b=2 at=start\n"
 	expected = expected + "a=1 b=2 at=finish elapsed=0.000\n"
-	expected = expected + "a=1 b=2 metric=bucket timing=0"
+	expected = expected + "metric=bucket timing=0"
 	if result := logged(buf); result != expected {
 		t.Errorf("Bad log output: %s", result)
 	}


### PR DESCRIPTION
This lets you setup a statter object in a Timer, so that finishing a timer will write to your stats service.  

First, setup a statter for a context:

``` go
// uses CurrentStatter, with a sample rate of 1.0 and the specified key
grohl.SetStatter(nil, 1.0, "foo.bar")
timer := grohl.NewTimer(nil)
// some work
timer.Finish()

// you can do this on any context object
context.SetStatter(myStatter, 1.0, "foo.bar")
timer := context.Timer(nil)
// some work
timer.Finish()

// you can also do this just for a timer
timer := context.Timer(nil)
timer.SetStatter(myStatter, 1.0, "foo.bar")
// some work
timer.Finish()
```

/cc @asenchi
