### PR TITLE
rename ExceptionReporter to ErrorReporter

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,10 +1,10 @@
 package grohl
 
 type Context struct {
-	data              Data
-	Logger            Logger
-	TimeUnit          string
-	ExceptionReporter ExceptionReporter
+	data          Data
+	Logger        Logger
+	TimeUnit      string
+	ErrorReporter ErrorReporter
 }
 
 func (c *Context) Log(data Data) error {
@@ -16,7 +16,7 @@ func (c *Context) log(data Data) error {
 }
 
 func (c *Context) New(data Data) *Context {
-	return &Context{c.Merge(data), c.Logger, c.TimeUnit, c.ExceptionReporter}
+	return &Context{c.Merge(data), c.Logger, c.TimeUnit, c.ErrorReporter}
 }
 
 func (c *Context) Add(key string, value interface{}) {

--- a/exceptions.go
+++ b/exceptions.go
@@ -6,17 +6,17 @@ import (
 	"runtime/debug"
 )
 
-type ExceptionReporter interface {
+type ErrorReporter interface {
 	Report(err error, data Data) error
 }
 
-// Implementation of ExceptionReporter that writes to a grohl logger.
+// Implementation of ErrorReporter that writes to a grohl logger.
 func (c *Context) Report(err error, data Data) error {
 	merged := c.Merge(data)
 	errorToMap(err, merged)
 
-	if c.ExceptionReporter != nil {
-		return c.ExceptionReporter.Report(err, merged)
+	if c.ErrorReporter != nil {
+		return c.ErrorReporter.Report(err, merged)
 	} else {
 		var logErr error
 		logErr = c.log(merged)


### PR DESCRIPTION
This name always bugged me in the context of Go programs.  Ruby raises exceptions, Go returns errors.  
