### PR TITLE
Protect against a race condition

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,10 +1,15 @@
 package grohl
 
+import (
+	"sync"
+)
+
 // A Context holds default key/value data that merges with the data every Log()
 // call receives.
 type Context struct {
 	data          Data
 	Logger        Logger
+	LoggerMutex   sync.Mutex
 	TimeUnit      string
 	ErrorReporter ErrorReporter
 	*_statter
@@ -13,10 +18,20 @@ type Context struct {
 // Log merges the given data with the Context's data, and passes it to the
 // Logger.
 func (c *Context) Log(data Data) error {
+	c.LoggerMutex.Lock()
+	defer c.LoggerMutex.Unlock()
 	return c.Logger.Log(c.Merge(data))
 }
 
+func (c *Context) SetLogger(logger Logger) {
+	c.LoggerMutex.Lock()
+	defer c.LoggerMutex.Unlock()
+	c.Logger = logger
+}
+
 func (c *Context) log(data Data) error {
+	c.LoggerMutex.Lock()
+	defer c.LoggerMutex.Unlock()
 	return c.Logger.Log(data)
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,7 @@
 package grohl
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -16,4 +17,14 @@ func TestContext(t *testing.T) {
 	if log := BuildLog(merged, false); log != expected {
 		t.Errorf("Expected: %s\nActual: %s", expected, log)
 	}
+}
+
+func TestContextHasNoRace(t *testing.T) {
+	c := make(chan int)
+	go func() {
+		SetLogger(NewIoLogger(new(bytes.Buffer)))
+		c <- 1
+	}()
+	SetLogger(NewIoLogger(new(bytes.Buffer)))
+	<-c
 }

--- a/doc.go
+++ b/doc.go
@@ -5,7 +5,7 @@ in a key=value structure.  It also provides interfaces for sending stacktraces
 or metrics to external services.
 
 This is a Go version of https://github.com/asenchi/scrolls. The name for this
-library came from mashing the words "go" and "scrolls" together.  Also, Dave 
+library came from mashing the words "go" and "scrolls" together.  Also, Dave
 Grohl (lead singer of Foo Fighters) is passionate about event driven metrics.
 
 Grohl treats logs as the central authority for how an application is behaving.

--- a/grohl.go
+++ b/grohl.go
@@ -1,6 +1,9 @@
 package grohl
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // Data is the map used to specify the key/value pairs for a logged message.
 type Data map[string]interface{}
@@ -12,6 +15,7 @@ type Logger interface {
 
 // CurrentLogger is the default Logger used by Log, Report.
 var CurrentLogger Logger = NewIoLogger(nil)
+var currentLoggerMutex sync.Mutex
 
 // CurrentContext is the default Context used by Log, Report, AddContext,
 // DeleteContext, NewTimer.
@@ -56,8 +60,10 @@ func SetLogger(logger Logger) Logger {
 		logger = NewIoLogger(nil)
 	}
 
+	currentLoggerMutex.Lock()
+	defer currentLoggerMutex.Unlock()
 	CurrentLogger = logger
-	CurrentContext.Logger = logger
+	CurrentContext.SetLogger(logger)
 
 	return logger
 }


### PR DESCRIPTION
There's a race condition around CurrentLogger and CurrentContext.Logger that particularly comes to light if SetLogger() is called in a goroutine. I discovered this running the race condition checker on a different project that uses grohl and added a test to grohl that would trigger the condition.
