### PR TITLE
Update for Go 1.3

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -12,8 +12,8 @@ func TestContextMerge(t *testing.T) {
 
 	merged := orig.Merge(Data{"b": 2, "c": 3})
 
-	AssertData(t, merged, []string{"a=1", "b=2", "c=3"})
-	AssertLog(t, orig, []string{"a=1", "b=1"})
+	AssertData(t, merged, "a=1", "b=2", "c=3")
+	AssertLog(t, orig, "a=1", "b=1")
 }
 
 func TestContextStatterPrefix(t *testing.T) {

--- a/context_test.go
+++ b/context_test.go
@@ -12,8 +12,8 @@ func TestContextMerge(t *testing.T) {
 
 	merged := orig.Merge(Data{"b": 2, "c": 3})
 
-	AssertData(t, "a=1 b=2 c=3", merged)
-	AssertLog(t, "a=1 b=1", orig)
+	AssertData(t, merged, []string{"a=1", "b=2", "c=3"})
+	AssertLog(t, orig, []string{"a=1", "b=1"})
 }
 
 func TestContextStatterPrefix(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -26,9 +26,9 @@ func TestLogsError(t *testing.T) {
 
 	for i, line := range buf.Lines() {
 		if i == 0 {
-			AssertBuildLine(t, line, firstRow...)
+			AssertBuiltLine(t, line, firstRow...)
 		} else {
-			AssertBuildLine(t, line, otherRows...)
+			AssertBuiltLine(t, line, otherRows...)
 		}
 	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -26,9 +26,9 @@ func TestLogsError(t *testing.T) {
 
 	for i, line := range buf.Lines() {
 		if i == 0 {
-			AssertBuildLine(t, line, firstRow)
+			AssertBuildLine(t, line, firstRow...)
 		} else {
-			AssertBuildLine(t, line, otherRows)
+			AssertBuildLine(t, line, otherRows...)
 		}
 	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,7 +2,6 @@ package grohl
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 )
 
@@ -14,18 +13,22 @@ func TestLogsError(t *testing.T) {
 	err := fmt.Errorf("Test")
 
 	reporter.Report(err, Data{"b": 2, "c": 3, "at": "overwrite me"})
-	expected := "a=1 b=2 c=3 at=exception class=*errors.errorString message=Test"
-	linePrefix := expected + " site="
+	firstRow := []string{
+		"a=1",
+		"b=2",
+		"c=3",
+		"at=exception",
+		"class=*errors.errorString",
+		"message=Test",
+	}
 
-	for i, line := range strings.Split(buf.String(), "\n") {
+	otherRows := append(firstRow, "site=")
+
+	for i, line := range buf.Lines() {
 		if i == 0 {
-			if line != expected {
-				t.Errorf("Line does not match:\ne: %s\na: %s", expected, line)
-			}
+			AssertBuildLine(t, line, firstRow)
 		} else {
-			if !strings.HasPrefix(line, linePrefix) {
-				t.Errorf("Line %d does not match:\ne: %s\na: %s", i+1, linePrefix, line)
-			}
+			AssertBuildLine(t, line, otherRows)
 		}
 	}
 }

--- a/format.go
+++ b/format.go
@@ -11,6 +11,10 @@ import (
 // BuildLog assembles a log message from the key/value data.  If addTime is true,
 // the current timestamp is logged with the "now" key.
 func BuildLog(data Data, addTime bool) string {
+	return strings.Join(BuildLogParts(data, addTime), space)
+}
+
+func BuildLogParts(data Data, addTime bool) []string {
 	index := 0
 	extraRows := 0
 	if addTime {
@@ -28,7 +32,7 @@ func BuildLog(data Data, addTime bool) string {
 		pieces[0] = fmt.Sprintf("now=%s", time.Now().UTC().Format(timeLayout))
 	}
 
-	return strings.Join(pieces, space)
+	return pieces
 }
 
 // Format converts the value into a string for the Logger output.

--- a/format_test.go
+++ b/format_test.go
@@ -95,7 +95,7 @@ func TestFormatWithTime(t *testing.T) {
 		t.Errorf("Invalid prefix: %s", line.full)
 	}
 
-	AssertBuildLine(t, line, "fn=time", "test=1", "~now=")
+	AssertBuiltLine(t, line, "fn=time", "test=1", "~now=")
 }
 
 func AssertLog(t *testing.T, ctx *Context, expected ...string) {
@@ -103,10 +103,10 @@ func AssertLog(t *testing.T, ctx *Context, expected ...string) {
 }
 
 func AssertData(t *testing.T, data Data, expected ...string) {
-	AssertBuildLine(t, buildLogLine(data), expected...)
+	AssertBuiltLine(t, buildLogLine(data), expected...)
 }
 
-func AssertBuildLine(t *testing.T, line builtLogLine, expected ...string) {
+func AssertBuiltLine(t *testing.T, line builtLogLine, expected ...string) {
 	for _, pair := range expected {
 		if strings.HasPrefix(pair, "~") {
 			pair = pair[1:len(pair)]

--- a/format_test.go
+++ b/format_test.go
@@ -98,14 +98,18 @@ func AssertLog(t *testing.T, ctx *Context, expected []string) {
 }
 
 func AssertData(t *testing.T, data Data, expected []string) {
-	pairs, line := buildLogMap(data)
+	AssertBuildLine(t, buildLogLine(data), expected)
+}
+
+func AssertBuildLine(t *testing.T, line builtLogLine, expected []string) {
 	for _, pair := range expected {
-		if _, ok := pairs[pair]; !ok {
-			t.Errorf("Expected pair '%s' in %s", pair, line)
+		if _, ok := line.pairs[pair]; !ok {
+			t.Errorf("Expected pair '%s' in %s", pair, line.full)
 		}
 	}
-	if expectedLen := len(expected); expectedLen != len(pairs) {
-		t.Errorf("Expected %d pairs in %s", expectedLen, line)
+
+	if expectedLen := len(expected); expectedLen != len(line.pairs) {
+		t.Errorf("Expected %d pairs in %s", expectedLen, line.full)
 	}
 }
 
@@ -115,11 +119,16 @@ func AssertString(t *testing.T, expected, actual string) {
 	}
 }
 
-func buildLogMap(d Data) (map[string]bool, string) {
+type builtLogLine struct {
+	pairs map[string]bool
+	full  string
+}
+
+func buildLogLine(d Data) builtLogLine {
 	m := make(map[string]bool)
 	parts := BuildLogParts(d, false)
 	for _, pair := range parts {
 		m[pair] = true
 	}
-	return m, strings.Join(parts, space)
+	return builtLogLine{m, strings.Join(parts, space)}
 }

--- a/format_test.go
+++ b/format_test.go
@@ -78,7 +78,7 @@ var expectations = [][]string{
 
 func TestFormat(t *testing.T) {
 	for i, actual := range actuals {
-		AssertData(t, actual, expectations[i])
+		AssertData(t, actual, expectations[i]...)
 	}
 }
 
@@ -95,18 +95,18 @@ func TestFormatWithTime(t *testing.T) {
 		t.Errorf("Invalid prefix: %s", line.full)
 	}
 
-	AssertBuildLine(t, line, []string{"fn=time", "test=1", "~now="})
+	AssertBuildLine(t, line, "fn=time", "test=1", "~now=")
 }
 
-func AssertLog(t *testing.T, ctx *Context, expected []string) {
-	AssertData(t, ctx.Merge(nil), expected)
+func AssertLog(t *testing.T, ctx *Context, expected ...string) {
+	AssertData(t, ctx.Merge(nil), expected...)
 }
 
-func AssertData(t *testing.T, data Data, expected []string) {
-	AssertBuildLine(t, buildLogLine(data), expected)
+func AssertData(t *testing.T, data Data, expected ...string) {
+	AssertBuildLine(t, buildLogLine(data), expected...)
 }
 
-func AssertBuildLine(t *testing.T, line builtLogLine, expected []string) {
+func AssertBuildLine(t *testing.T, line builtLogLine, expected ...string) {
 	for _, pair := range expected {
 		if strings.HasPrefix(pair, "~") {
 			pair = pair[1:len(pair)]

--- a/format_test.go
+++ b/format_test.go
@@ -14,96 +14,71 @@ type ExampleStruct struct {
 	Value interface{}
 }
 
-var examples = map[string]Data{
-	"fn=string test=hi": Data{
-		"fn": "string", "test": "hi",
-	},
-	`fn=stringspace test="a b"`: Data{
-		"fn": "stringspace", "test": "a b",
-	},
-	`fn=stringslasher test="slasher \\\\"`: Data{
-		"fn": "stringslasher", "test": `slasher \\`,
-	},
-	`fn=stringeqspace test="x=4, y=10"`: Data{
-		"fn": "stringeqspace", "test": "x=4, y=10",
-	},
-	`fn=stringeq test="x=4,y=10"`: Data{
-		"fn": "stringeq", "test": "x=4,y=10",
-	},
-	`fn=stringspace test="hello world"`: Data{
-		"fn": "stringspace", "test": "hello world",
-	},
-	`fn=stringbothquotes test="echo 'hello' \"world\""`: Data{
-		"fn": "stringbothquotes", "test": `echo 'hello' "world"`,
-	},
-	`fn=stringsinglequotes test="a 'a'"`: Data{
-		"fn": "stringsinglequotes", "test": `a 'a'`,
-	},
-	`fn=stringdoublequotes test='echo "hello"'`: Data{
-		"fn": "stringdoublequotes", "test": `echo "hello"`,
-	},
-	`fn=stringbothquotesnospace test='a"`: Data{
-		"fn": "stringbothquotesnospace", "test": `'a"`,
-	},
-	"fn=emptystring test=nil": Data{
-		"fn": "emptystring", "test": "",
-	},
-	"fn=int test=1": Data{
-		"fn": "int", "test": int(1),
-	},
-	"fn=int8 test=1": Data{
-		"fn": "int8", "test": int8(1),
-	},
-	"fn=int16 test=1": Data{
-		"fn": "int16", "test": int16(1),
-	},
-	"fn=int32 test=1": Data{
-		"fn": "int32", "test": int32(1),
-	},
-	"fn=int64 test=1": Data{
-		"fn": "int64", "test": int64(1),
-	},
-	"fn=uint test=1": Data{
-		"fn": "uint", "test": uint(1),
-	},
-	"fn=uint8 test=1": Data{
-		"fn": "uint8", "test": uint8(1),
-	},
-	"fn=uint16 test=1": Data{
-		"fn": "uint16", "test": uint16(1),
-	},
-	"fn=uint32 test=1": Data{
-		"fn": "uint32", "test": uint32(1),
-	},
-	"fn=uint64 test=1": Data{
-		"fn": "uint64", "test": uint64(1),
-	},
-	"fn=float test=1.000": Data{
-		"fn": "float", "test": float32(1.0),
-	},
-	"fn=bool test=true": Data{
-		"fn": "bool", "test": true,
-	},
-	"fn=nil test=nil": Data{
-		"fn": "nil", "test": nil,
-	},
-	"fn=time test=2000-01-02T03:04:05+0000": Data{
-		"fn": "time", "test": exampleTime,
-	},
-	`fn=error test="error message"`: Data{
-		"fn": "error", "test": exampleError,
-	},
-	`fn=slice test="[86 87 88]"`: Data{
-		"fn": "slice", "test": []byte{86, 87, 88},
-	},
-	`fn=struct test={Value:testing123}`: Data{
-		"fn": "struct", "test": ExampleStruct{Value: "testing123"},
-	},
+var actuals = []Data{
+	Data{"fn": "string", "test": "hi"},
+	Data{"fn": "stringspace", "test": "a b"},
+	Data{"fn": "stringslasher", "test": `slasher \\`},
+	Data{"fn": "stringeqspace", "test": "x=4, y=10"},
+	Data{"fn": "stringeq", "test": "x=4,y=10"},
+	Data{"fn": "stringspace", "test": "hello world"},
+	Data{"fn": "stringbothquotes", "test": `echo 'hello' "world"`},
+	Data{"fn": "stringsinglequotes", "test": `a 'a'`},
+	Data{"fn": "stringdoublequotes", "test": `echo "hello"`},
+	Data{"fn": "stringbothquotesnospace", "test": `'a"`},
+	Data{"fn": "emptystring", "test": ""},
+	Data{"fn": "int", "test": int(1)},
+	Data{"fn": "int8", "test": int8(1)},
+	Data{"fn": "int16", "test": int16(1)},
+	Data{"fn": "int32", "test": int32(1)},
+	Data{"fn": "int64", "test": int64(1)},
+	Data{"fn": "uint", "test": uint(1)},
+	Data{"fn": "uint8", "test": uint8(1)},
+	Data{"fn": "uint16", "test": uint16(1)},
+	Data{"fn": "uint32", "test": uint32(1)},
+	Data{"fn": "uint64", "test": uint64(1)},
+	Data{"fn": "float", "test": float32(1.0)},
+	Data{"fn": "bool", "test": true},
+	Data{"fn": "nil", "test": nil},
+	Data{"fn": "time", "test": exampleTime},
+	Data{"fn": "error", "test": exampleError},
+	Data{"fn": "slice", "test": []byte{86, 87, 88}},
+	Data{"fn": "struct", "test": ExampleStruct{Value: "testing123"}},
+}
+
+var expectations = [][]string{
+	[]string{"fn=string", "test=hi"},
+	[]string{"fn=stringspace", `test="a b"`},
+	[]string{`fn=stringslasher`, `test="slasher \\\\"`},
+	[]string{`fn=stringeqspace`, `test="x=4, y=10"`},
+	[]string{`fn=stringeq`, `test="x=4,y=10"`},
+	[]string{`fn=stringspace`, `test="hello world"`},
+	[]string{`fn=stringbothquotes`, `test="echo 'hello' \"world\""`},
+	[]string{`fn=stringsinglequotes`, `test="a 'a'"`},
+	[]string{`fn=stringdoublequotes`, `test='echo "hello"'`},
+	[]string{`fn=stringbothquotesnospace`, `test='a"`},
+	[]string{"fn=emptystring", "test=nil"},
+	[]string{"fn=int", "test=1"},
+	[]string{"fn=int8", "test=1"},
+	[]string{"fn=int16", "test=1"},
+	[]string{"fn=int32", "test=1"},
+	[]string{"fn=int64", "test=1"},
+	[]string{"fn=uint", "test=1"},
+	[]string{"fn=uint8", "test=1"},
+	[]string{"fn=uint16", "test=1"},
+	[]string{"fn=uint32", "test=1"},
+	[]string{"fn=uint64", "test=1"},
+	[]string{"fn=float", "test=1.000"},
+	[]string{"fn=bool", "test=true"},
+	[]string{"fn=nil", "test=nil"},
+	[]string{"fn=time", "test=2000-01-02T03:04:05+0000"},
+	[]string{`fn=error`, `test="error message"`},
+	[]string{`fn=slice`, `test="[86 87 88]"`},
+	[]string{`fn=struct`, `test={Value:testing123}`},
 }
 
 func TestFormat(t *testing.T) {
-	for expected, data := range examples {
-		AssertData(t, expected, data)
+	for i, actual := range actuals {
+		AssertData(t, actual, expectations[i])
 	}
 }
 
@@ -118,13 +93,19 @@ func TestFormatWithTime(t *testing.T) {
 	}
 }
 
-func AssertLog(t *testing.T, expected string, ctx *Context) {
-	AssertData(t, expected, ctx.Merge(nil))
+func AssertLog(t *testing.T, ctx *Context, expected []string) {
+	AssertData(t, ctx.Merge(nil), expected)
 }
 
-func AssertData(t *testing.T, expected string, data Data) {
-	if actual := BuildLog(data, false); expected != actual {
-		t.Errorf("Expected %s\nfrom: %v\nGot: %s", expected, data, actual)
+func AssertData(t *testing.T, data Data, expected []string) {
+	pairs, line := buildLogMap(data)
+	for _, pair := range expected {
+		if _, ok := pairs[pair]; !ok {
+			t.Errorf("Expected pair '%s' in %s", pair, line)
+		}
+	}
+	if expectedLen := len(expected); expectedLen != len(pairs) {
+		t.Errorf("Expected %d pairs in %s", expectedLen, line)
 	}
 }
 
@@ -132,4 +113,13 @@ func AssertString(t *testing.T, expected, actual string) {
 	if expected != actual {
 		t.Errorf("Expected %s\nGot: %s", expected, actual)
 	}
+}
+
+func buildLogMap(d Data) (map[string]bool, string) {
+	m := make(map[string]bool)
+	parts := BuildLogParts(d, false)
+	for _, pair := range parts {
+		m[pair] = true
+	}
+	return m, strings.Join(parts, space)
 }

--- a/loggers_test.go
+++ b/loggers_test.go
@@ -2,7 +2,6 @@ package grohl
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 )
 
@@ -38,24 +37,46 @@ func TestChannelLog(t *testing.T) {
 type loggerBuffer struct {
 	channel chan Data
 	t       *testing.T
+	lines   []builtLogLine
+	index   int
 }
 
-func (b *loggerBuffer) String() string {
-	close(b.channel)
-	lines := make([]string, len(b.channel))
-	i := 0
+func (b *loggerBuffer) Lines() []builtLogLine {
+	if b.lines == nil {
+		close(b.channel)
+		b.lines = make([]builtLogLine, len(b.channel))
+		i := 0
 
-	for data := range b.channel {
-		lines[i] = BuildLog(data, false)
-		i = i + 1
+		for data := range b.channel {
+			b.lines[i] = buildLogLine(data)
+			i = i + 1
+		}
 	}
 
-	return strings.Join(lines, "\n")
+	return b.lines
 }
 
-func (b *loggerBuffer) AssertLogged(expected string) {
-	if result := b.String(); result != expected {
-		b.t.Errorf("Bad log output: %s", result)
+func (b *loggerBuffer) AssertLine(parts ...string) {
+	lines := b.Lines()
+	if b.index < 0 || b.index >= len(lines) {
+		b.t.Errorf("No line %d", b.index)
+		return
+	}
+
+	AssertBuildLine(b.t, lines[b.index], parts)
+	b.index += 1
+}
+
+func (b *loggerBuffer) AssertEOF() {
+	lines := b.Lines()
+	if b.index < 0 {
+		b.t.Errorf("Invalid index %d", b.index)
+		return
+	}
+
+	if b.index < len(lines) {
+		b.t.Errorf("Not EOF, on line %d", b.index)
+		return
 	}
 }
 
@@ -64,5 +85,5 @@ func setupLogger(t *testing.T) (*Context, *loggerBuffer) {
 	logger, _ := NewChannelLogger(ch)
 	context := NewContext(nil)
 	context.Logger = logger
-	return context, &loggerBuffer{ch, t}
+	return context, &loggerBuffer{channel: ch, t: t}
 }

--- a/loggers_test.go
+++ b/loggers_test.go
@@ -63,7 +63,7 @@ func (b *loggerBuffer) AssertLine(parts ...string) {
 		return
 	}
 
-	AssertBuildLine(b.t, lines[b.index], parts...)
+	AssertBuiltLine(b.t, lines[b.index], parts...)
 	b.index += 1
 }
 

--- a/loggers_test.go
+++ b/loggers_test.go
@@ -63,7 +63,7 @@ func (b *loggerBuffer) AssertLine(parts ...string) {
 		return
 	}
 
-	AssertBuildLine(b.t, lines[b.index], parts)
+	AssertBuildLine(b.t, lines[b.index], parts...)
 	b.index += 1
 }
 

--- a/statter_test.go
+++ b/statter_test.go
@@ -8,7 +8,9 @@ import (
 func TestLogsCounter(t *testing.T) {
 	s, buf := setupLogger(t)
 	s.Counter(1.0, "a", 1, 2)
-	buf.AssertLogged("metric=a count=1\nmetric=a count=2")
+	buf.AssertLine("metric=a", "count=1")
+	buf.AssertLine("metric=a", "count=2")
+	buf.AssertEOF()
 }
 
 func TestLogsTiming(t *testing.T) {
@@ -17,13 +19,17 @@ func TestLogsTiming(t *testing.T) {
 	dur2, _ := time.ParseDuration("3s")
 
 	s.Timing(1.0, "a", dur1, dur2)
-	buf.AssertLogged("metric=a timing=15\nmetric=a timing=3000")
+	buf.AssertLine("metric=a", "timing=15")
+	buf.AssertLine("metric=a", "timing=3000")
+	buf.AssertEOF()
 }
 
 func TestLogsGauge(t *testing.T) {
 	s, buf := setupLogger(t)
 	s.Gauge(1.0, "a", "1", "2")
-	buf.AssertLogged("metric=a gauge=1\nmetric=a gauge=2")
+	buf.AssertLine("metric=a", "gauge=1")
+	buf.AssertLine("metric=a", "gauge=2")
+	buf.AssertEOF()
 }
 
 var suffixTests = []string{"abc", "abc."}

--- a/timer_test.go
+++ b/timer_test.go
@@ -23,7 +23,7 @@ func TestTimerLogInMS(t *testing.T) {
 	timer.Log(Data{"c": "3"})
 
 	buf.AssertLine("a=1", "b=2", "at=start")
-	buf.AssertLine("a=1", "b=2", "c=3", "elapsed=0.001")
+	buf.AssertLine("a=1", "b=2", "c=3", "~elapsed=0.00")
 	buf.AssertEOF()
 }
 

--- a/timer_test.go
+++ b/timer_test.go
@@ -10,7 +10,9 @@ func TestTimerLog(t *testing.T) {
 	timer := context.Timer(Data{"b": "2"})
 	timer.Log(Data{"c": "3"})
 
-	buf.AssertLogged("a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.000")
+	buf.AssertLine("a=1", "b=2", "at=start")
+	buf.AssertLine("a=1", "b=2", "c=3", "elapsed=0.000")
+	buf.AssertEOF()
 }
 
 func TestTimerLogInMS(t *testing.T) {
@@ -20,11 +22,9 @@ func TestTimerLogInMS(t *testing.T) {
 	timer.TimeUnit = "ms"
 	timer.Log(Data{"c": "3"})
 
-	expected := "a=1 b=2 at=start\na=1 b=2 c=3 elapsed=0.001"
-	checkedLen := len(expected) - 3
-	if result := buf.String(); result[0:checkedLen] != expected[0:checkedLen] {
-		t.Errorf("Bad log output: %s", result)
-	}
+	buf.AssertLine("a=1", "b=2", "at=start")
+	buf.AssertLine("a=1", "b=2", "c=3", "elapsed=0.001")
+	buf.AssertEOF()
 }
 
 func TestTimerFinish(t *testing.T) {
@@ -33,7 +33,9 @@ func TestTimerFinish(t *testing.T) {
 	timer := context.Timer(Data{"b": "2"})
 	timer.Finish()
 
-	buf.AssertLogged("a=1 b=2 at=start\na=1 b=2 at=finish elapsed=0.000")
+	buf.AssertLine("a=1", "b=2", "at=start")
+	buf.AssertLine("a=1", "b=2", "at=finish", "elapsed=0.000")
+	buf.AssertEOF()
 }
 
 func TestTimerWithStatter(t *testing.T) {
@@ -45,10 +47,10 @@ func TestTimerWithStatter(t *testing.T) {
 	timer.SetStatter(statter, 1.0, "bucket")
 	timer.Finish()
 
-	expected := "a=1 b=2 at=start\n"
-	expected = expected + "metric=bucket timing=0\n"
-	expected = expected + "a=1 b=2 at=finish elapsed=0.000"
-	buf.AssertLogged(expected)
+	buf.AssertLine("a=1", "b=2", "at=start")
+	buf.AssertLine("metric=bucket", "timing=0")
+	buf.AssertLine("a=1", "b=2", "at=finish", "elapsed=0.000")
+	buf.AssertEOF()
 }
 
 func TestTimerWithContextStatter(t *testing.T) {
@@ -59,10 +61,10 @@ func TestTimerWithContextStatter(t *testing.T) {
 	timer.StatterBucket = "bucket2"
 	timer.Finish()
 
-	expected := "a=1 b=2 at=start\n"
-	expected = expected + "a=1 metric=bucket2 timing=0\n"
-	expected = expected + "a=1 b=2 at=finish elapsed=0.000"
-	buf.AssertLogged(expected)
+	buf.AssertLine("a=1", "b=2", "at=start")
+	buf.AssertLine("a=1", "metric=bucket2", "timing=0")
+	buf.AssertLine("a=1", "b=2", "at=finish", "elapsed=0.000")
+	buf.AssertEOF()
 
 	if context.StatterBucket == "bucket2" {
 		t.Errorf("Context's stat bucket was changed")
@@ -80,9 +82,8 @@ func TestTimerWithNilStatter(t *testing.T) {
 	timer.Finish()
 
 	CurrentContext.Logger = oldlogger
-
-	expected := "a=1 b=2 at=start\n"
-	expected = expected + "metric=bucket timing=0\n"
-	expected = expected + "a=1 b=2 at=finish elapsed=0.000"
-	buf.AssertLogged(expected)
+	buf.AssertLine("a=1", "b=2", "at=start")
+	buf.AssertLine("metric=bucket", "timing=0")
+	buf.AssertLine("a=1", "b=2", "at=finish", "elapsed=0.000")
+	buf.AssertEOF()
 }


### PR DESCRIPTION
In Go 1.3, maps are iterated in random order.  This changes the tests to assert built lines by passing in an array of string key/value pairs (like `"a=1"`).  This confirms that all pairs are in the line, but not necessarily in the same order.
