### PR TITLE
Prevent issues with stacks exactly 11 deep

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,8 +38,7 @@ func (c *Context) Report(err error, data Data) error {
 
 // ErrorBacktrace creates a backtrace of the call stack.
 func ErrorBacktrace(err error) string {
-	lines := errorBacktraceBytes(err)
-	return string(bytes.Join(lines, byteLineBreak))
+	return string(debug.Stack())
 }
 
 // ErrorBacktraceLines creates a backtrace of the call stack, split into lines.
@@ -55,9 +54,7 @@ func ErrorBacktraceLines(err error) []string {
 }
 
 func errorBacktraceBytes(err error) [][]byte {
-	backtrace := debug.Stack()
-	all := bytes.Split(backtrace, byteLineBreak)
-	return all
+	return bytes.Split(debug.Stack(), byteLineBreak)
 }
 
 func errorToMap(err error, data Data) {

--- a/errors.go
+++ b/errors.go
@@ -45,9 +45,11 @@ func ErrorBacktrace(err error) string {
 // ErrorBacktraceLines creates a backtrace of the call stack, split into lines.
 func ErrorBacktraceLines(err error) []string {
 	byteLines := errorBacktraceBytes(err)
-	lines := make([]string, len(byteLines))
-	for i, byteline := range byteLines {
-		lines[i] = string(byteline)
+	lines := make([]string, 0, len(byteLines))
+
+	// skip top two frames which are this method and `errorBacktraceBytes`
+	for i := 2; i < len(byteLines); i++ {
+		lines = append(lines, string(byteLines[i]))
 	}
 	return lines
 }

--- a/errors.go
+++ b/errors.go
@@ -55,11 +55,7 @@ func ErrorBacktraceLines(err error) []string {
 func errorBacktraceBytes(err error) [][]byte {
 	backtrace := debug.Stack()
 	all := bytes.Split(backtrace, byteLineBreak)
-	if len(all) <= 10 {
-		return all
-	} else {
-		return all[0:10]
-	}
+	return all
 }
 
 func errorToMap(err error, data Data) {

--- a/errors.go
+++ b/errors.go
@@ -55,10 +55,10 @@ func ErrorBacktraceLines(err error) []string {
 func errorBacktraceBytes(err error) [][]byte {
 	backtrace := debug.Stack()
 	all := bytes.Split(backtrace, byteLineBreak)
-	if len(all) < 11 {
+	if len(all) <= 10 {
 		return all
 	} else {
-		return all[10 : len(all)-1]
+		return all[0:10]
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -22,7 +22,7 @@ func TestLogsError(t *testing.T) {
 		"message=Test",
 	}
 
-	otherRows := append(firstRow, "site=")
+	otherRows := append(firstRow, "~site=")
 
 	for i, line := range buf.Lines() {
 		if i == 0 {


### PR DESCRIPTION
I was seeing `panic serving 10.40.243.118:44663: runtime error: index
out of range` `/tmp/build_c0c3d66e-c25b-42a1-9bf2-a77b92b2f44c/.vendor/src/github.com/github/go-opstocat/haystack.go:36+0x65a` when attempting to report an exception via grohl + go-opstocat.

[haystack.go:36](https://github.com/github/go-opstocat/blob/7faea155fd76d1c43f9dd30622664674586cbbc1/haystack.go#L36) attempts to grab the first frame in the backtrace, but apparently the slice was empty!

I found this bit of code which, as it was previously written, returns an empty slice if the stack is exactly 11 frames deep.

I think the intention was to always grab the top 10 stack frames; if so, I think it can be rewritten like this. Reminder that go's slice range indices are exclusive: `[0:10]` means grab elements 0 through 9.

/cc: @technoweenie
