### PR TITLE
Error wrapping

### DIFF
--- a/context.go
+++ b/context.go
@@ -41,6 +41,11 @@ func (c *Context) Merge(data Data) Data {
 	}
 }
 
+// Data returns the Context's current Data.
+func (c *Context) Data() Data {
+	return c.data
+}
+
 // Delete removes the key from the Context's data.
 func (c *Context) Delete(key string) {
 	delete(c.data, key)

--- a/errors.go
+++ b/errors.go
@@ -2,9 +2,82 @@ package grohl
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
-	"runtime/debug"
+	"runtime"
 )
+
+type Error struct {
+	Message    string
+	reportable bool
+	InnerError error
+	Data       Data
+	stack      []byte
+}
+
+type HttpError struct {
+	StatusCode int
+	*Error
+}
+
+// NewError wraps an error with the error's message.
+func NewError(err error) *Error {
+	return NewErrorf(err, "")
+}
+
+// NewErrorf wraps an error with a formatted message.
+func NewErrorf(err error, format string, a ...interface{}) *Error {
+	var msg string
+	if len(format) > 0 {
+		msg = fmt.Sprintf(format, a...)
+	} else if err != nil {
+		msg = err.Error()
+	}
+
+	return &Error{
+		Message:    msg,
+		reportable: true,
+		InnerError: err,
+		Data:       Data{},
+		stack:      Stack(),
+	}
+}
+
+// NewHttpError wraps an error with an HTTP status code and the given error's
+// message.
+func NewHttpError(err error, status int) *HttpError {
+	return NewHttpErrorf(err, status, "")
+}
+
+// NewHttpErrorf wraps an error with an HTTP status code and a formatted message.
+func NewHttpErrorf(err error, status int, format string, a ...interface{}) *HttpError {
+	if status < 1 {
+		status = 500
+	}
+	return &HttpError{status, NewErrorf(err, format, a...)}
+}
+
+// Error returns the error message.  This will be the inner error's message,
+// unless a formatted message is provided from Errorf().
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// Stack returns the runtime stack stored with this Error.
+func (e *Error) Stack() []byte {
+	return e.stack
+}
+
+func (e *Error) Reportable() bool {
+	return e.reportable
+}
+
+// Stack returns the current runtime stack (up to 1MB).
+func Stack() []byte {
+	stackBuf := make([]byte, 1024*1024)
+	written := runtime.Stack(stackBuf, false)
+	return stackBuf[:written]
+}
 
 type ErrorReporter interface {
 	Report(err error, data Data) error
@@ -38,12 +111,12 @@ func (c *Context) Report(err error, data Data) error {
 
 // ErrorBacktrace creates a backtrace of the call stack.
 func ErrorBacktrace(err error) string {
-	return string(debug.Stack())
+	return string(errorStack(err))
 }
 
 // ErrorBacktraceLines creates a backtrace of the call stack, split into lines.
 func ErrorBacktraceLines(err error) []string {
-	byteLines := errorBacktraceBytes(err)
+	byteLines := bytes.Split(errorStack(err), byteLineBreak)
 	lines := make([]string, 0, len(byteLines))
 
 	// skip top two frames which are this method and `errorBacktraceBytes`
@@ -53,8 +126,15 @@ func ErrorBacktraceLines(err error) []string {
 	return lines
 }
 
-func errorBacktraceBytes(err error) [][]byte {
-	return bytes.Split(debug.Stack(), byteLineBreak)
+type stackedError interface {
+	Stack() []byte
+}
+
+func errorStack(err error) []byte {
+	if sErr, ok := err.(stackedError); ok {
+		return sErr.Stack()
+	}
+	return Stack()
 }
 
 func errorToMap(err error, data Data) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -101,8 +101,8 @@ func TestLogsWrappedError(t *testing.T) {
 		"c=3",
 		"d=4",
 		"at=exception",
-		"class=*grohl.Error",
-		"message=wat",
+		"class=*grohl.Err",
+		"message=sup",
 	}
 
 	otherRows := append(firstRow, "~site=")

--- a/errors_test.go
+++ b/errors_test.go
@@ -84,6 +84,38 @@ func TestWrapNilErrorWithMessage(t *testing.T) {
 	}
 }
 
+func TestLogsWrappedError(t *testing.T) {
+	err := errors.New("sup")
+	e := NewErrorf(err, "wat")
+	e.Add("b", 2)
+	e.Add("c", 2)
+
+	reporter, buf := setupLogger(t)
+	reporter.Add("a", 1)
+	reporter.Add("b", 1)
+
+	reporter.Report(e, Data{"c": 3, "d": 4, "at": "overwrite"})
+	firstRow := []string{
+		"a=1",
+		"b=2",
+		"c=3",
+		"d=4",
+		"at=exception",
+		"class=*grohl.Error",
+		"message=wat",
+	}
+
+	otherRows := append(firstRow, "~site=")
+
+	for i, line := range buf.Lines() {
+		if i == 0 {
+			AssertBuiltLine(t, line, firstRow...)
+		} else {
+			AssertBuiltLine(t, line, otherRows...)
+		}
+	}
+}
+
 func TestLogsError(t *testing.T) {
 	reporter, buf := setupLogger(t)
 	reporter.Add("a", 1)

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,9 +1,88 @@
 package grohl
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
+
+func TestWrapHttpError(t *testing.T) {
+	err := errors.New("sup")
+	e := NewHttpError(err, 0)
+	if e.Message != "sup" {
+		t.Errorf("Unexpected error message: %s", e.Message)
+	}
+
+	if e.StatusCode != 500 {
+		t.Errorf("Unexpected status code: %d", e.StatusCode)
+	}
+
+	if e.InnerError != err {
+		t.Errorf("Unexpected inner error: %v", e.InnerError)
+	}
+}
+
+func TestWrapHttpErrorWithStatus(t *testing.T) {
+	err := errors.New("sup")
+	e := NewHttpError(err, 409)
+	if e.Message != "sup" {
+		t.Errorf("Unexpected error message: %s", e.Message)
+	}
+
+	if e.StatusCode != 409 {
+		t.Errorf("Unexpected status code: %d", e.StatusCode)
+	}
+
+	if e.InnerError != err {
+		t.Errorf("Unexpected inner error: %v", e.InnerError)
+	}
+}
+
+func TestWrapError(t *testing.T) {
+	err := errors.New("sup")
+	e := NewError(err)
+	if e.Message != "sup" {
+		t.Errorf("Unexpected error message: %s", e.Message)
+	}
+
+	if e.InnerError != err {
+		t.Errorf("Unexpected inner error: %v", e.InnerError)
+	}
+}
+
+func TestWrapErrorWithMessage(t *testing.T) {
+	err := errors.New("sup")
+	e := NewErrorf(err, "nuff said, %s", "bub")
+	if e.Message != "nuff said, bub" {
+		t.Errorf("Unexpected error message: %s", e.Message)
+	}
+
+	if e.InnerError != err {
+		t.Errorf("Unexpected inner error: %v", e.InnerError)
+	}
+}
+
+func TestWrapNilError(t *testing.T) {
+	e := NewError(nil)
+	if e.Message != "" {
+		t.Errorf("Expected empty error message: %s", e.Message)
+	}
+
+	if e.InnerError != nil {
+		t.Errorf("Expected nil inner error: %v", e.InnerError)
+	}
+}
+
+func TestWrapNilErrorWithMessage(t *testing.T) {
+	e := NewErrorf(nil, "nuff said, %s", "bub")
+	if e.Message != "nuff said, bub" {
+		t.Errorf("Unexpected error message: %s", e.Message)
+	}
+
+	if e.InnerError != nil {
+		t.Errorf("Expected nil inner error: %v", e.InnerError)
+	}
+}
 
 func TestLogsError(t *testing.T) {
 	reporter, buf := setupLogger(t)


### PR DESCRIPTION
Trying to answer my own question from #17.
- Wrap an error with a user-visible error message.  
- Add the stack from `runtime.Stack()` at the time the error was created, not [when it's reported](https://github.com/technoweenie/grohl/blob/2bcb53d3f65b2ecb54612869abec02823316c77a/errors.go#L41).  I find this gives more accurate stack traces.
- For web applications, track the HTTP status code to return.
- Errors can return `false` for Reportable().  This way errors can be used for user-visible error messages without being sent to the error reporter.
- Errors can have their own grohl context.

I didn't go with the `errgo` package because it doesn't seem to track the stack trace.  Stack traces are really useful for our high level app code.

Also, this `*grohl.Error` type is not required by grohl at all.  Pass in your own errors, and implement the interfaces that make sense to your use case.
